### PR TITLE
All unit tests running using GitHub actions

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -33,7 +33,7 @@ jobs:
           unzip temp.zip
 
       - name: Inspect testdata
-        run: docker run -v $PWD/pysilcam-testdata:/testdata tankefugl/pysilcam ls /testdata -al
+        run: docker run -v $PWD/pysilcam-testdata:/testdata tankefugl/pysilcam:github-ci ls /testdata -al
 
       - name: Run the tests
-        run: docker run -v $PWD/pysilcam-testdata:/testdata tankefugl/pysilcam
+        run: docker run -v $PWD/pysilcam-testdata:/testdata tankefugl/pysilcam:github-ci

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -21,4 +21,27 @@ jobs:
         run: docker build . -f Dockerfile -t pysilcam
 
       - name: Run the tests
-        run: docker run pysilcam
+        run: docker run -v testdata:/testdata pysilcam
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7.4
+          architecture: x64
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run flake8
+        uses: suo/flake8-github-action@releases/v1
+        with:
+          checkName: 'lint'   # NOTE: this needs to be the same as the job name
+
+

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -10,6 +10,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Build the Docker image
+        run: docker build . -f Dockerfile -t pysilcam
+
       - name: Checkout test data
         uses: actions/checkout@v2
         with:
@@ -17,31 +20,6 @@ jobs:
           lfs: true
           path: testdata
 
-      - name: Build the Docker image
-        run: docker build . -f Dockerfile -t pysilcam
-
       - name: Run the tests
         run: docker run -v testdata:/testdata pysilcam
 
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8.2
-          architecture: x64
-
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Install flake8
-        run: pip install flake8
-
-      - name: Run flake8
-        uses: suo/flake8-github-action@releases/v1
-        with:
-          checkName: 'lint'   # NOTE: this needs to be the same as the job name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
           ls pysilcam-testdata/ -al
 
       - name: Inspect testdata
-        run: docker run -v pysilcam-testdata:/testdata pysilcam ls /testdata -al
+        run: docker run --entrypoint /bin/bash -v pysilcam-testdata:/testdata pysilcam ls /testdata -al
 
       - name: Run the tests
         run: docker run -v pysilcam-testdata:/testdata pysilcam

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -43,5 +43,5 @@ jobs:
         uses: suo/flake8-github-action@releases/v1
         with:
           checkName: 'lint'   # NOTE: this needs to be the same as the job name
-
-
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -10,18 +10,28 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Build the Docker image
-        run: docker build . -f Dockerfile -t pysilcam
+      - uses: whoan/docker-build-with-cache-action@v4
+        with:
+          push_image_and_stages: false  # useful when you are setting a workflow to run on PRs
+          image_name: pysilcam
+          context: .
+          dockerfile: Dockerfile
+
+      # - name: Build the Docker image
+      #   run: docker build . -f Dockerfile -t pysilcam
 
       - name: Download test data
         shell: bash
         env:
           AZURE_TEST_DATA_ACCESS_TOKEN: ${{ secrets.AZURE_TEST_DATA_ACCESS_TOKEN }}
         run: |
-          wget https://pysilcam.blob.core.windows.net/test-data/pysilcam-testdata.zip?$AZURE_TEST_DATA_ACCESS_TOKEN -O temp.zip
+          wget -q https://pysilcam.blob.core.windows.net/test-data/pysilcam-testdata.zip?$AZURE_TEST_DATA_ACCESS_TOKEN -O temp.zip
           unzip temp.zip
           ls -al
           ls pysilcam-testdata/ -al
+
+      - name: Inspect testdata
+        run: docker run -v pysilcam-testdata:/testdata pysilcam ls /testdata -al
 
       - name: Run the tests
         run: docker run -v pysilcam-testdata:/testdata pysilcam

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -12,8 +12,12 @@ jobs:
 
       - uses: whoan/docker-build-with-cache-action@v4
         with:
-          push_image_and_stages: false  # useful when you are setting a workflow to run on PRs
-          image_name: pysilcam
+          #push_image_and_stages: true  # useful when you are setting a workflow to run on PRs
+          username: tankefugl
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          #registry: Docker registry (default: Docker Hub's registry).
+          image_name: tankefugl/pysilcam #sintef/pysilcam?
+          image_tag: github-ci
           context: .
           dockerfile: Dockerfile
 
@@ -29,7 +33,7 @@ jobs:
           unzip temp.zip
 
       - name: Inspect testdata
-        run: docker run -v ./pysilcam-testdata:/testdata pysilcam ls /testdata -al
+        run: docker run -v $PWD/pysilcam-testdata:/testdata pysilcam ls /testdata -al
 
       - name: Run the tests
-        run: docker run -v ./pysilcam-testdata:/testdata pysilcam
+        run: docker run -v $PWD/pysilcam-testdata:/testdata pysilcam

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -25,13 +25,11 @@ jobs:
         env:
           AZURE_TEST_DATA_ACCESS_TOKEN: ${{ secrets.AZURE_TEST_DATA_ACCESS_TOKEN }}
         run: |
-          wget -q https://pysilcam.blob.core.windows.net/test-data/pysilcam-testdata.zip?$AZURE_TEST_DATA_ACCESS_TOKEN -O temp.zip
+          wget -nv https://pysilcam.blob.core.windows.net/test-data/pysilcam-testdata.zip?$AZURE_TEST_DATA_ACCESS_TOKEN -O temp.zip
           unzip temp.zip
-          ls -al
-          ls pysilcam-testdata/ -al
 
       - name: Inspect testdata
-        run: docker run --entrypoint /bin/bash -v pysilcam-testdata:/testdata pysilcam ls /testdata -al
+        run: docker run -v ./pysilcam-testdata:/testdata pysilcam ls /testdata -al
 
       - name: Run the tests
-        run: docker run -v pysilcam-testdata:/testdata pysilcam
+        run: docker run -v ./pysilcam-testdata:/testdata pysilcam

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -7,10 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Build the Docker image
-        run: docker build . -f Dockerfile -t pysilcam
+      - name: Check out code
+        uses: actions/checkout@v2
 
       - name: Checkout test data
         uses: actions/checkout@v2
@@ -18,6 +16,9 @@ jobs:
           repository: SINTEF/pysilcam-testdata
           lfs: true
           path: testdata
+
+      - name: Build the Docker image
+        run: docker build . -f Dockerfile -t pysilcam
 
       - name: Run the tests
         run: docker run pysilcam

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.4
+          python-version: 3.8.2
           architecture: x64
 
       - name: Check out code

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -2,6 +2,10 @@ name: Docker build and test
 
 on: [push, pull_request]
 
+env:
+  IMAGE_NAME: sintef/pysilcam
+  IMAGE_TAG: github-ci
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,8 +22,8 @@ jobs:
           # username: <username>
           # password: ${{ secrets.DOCKER_REGISTRY_ACCESS_TOKEN }}
           # registry: <docker registry> (default: Docker Hub's registry).
-          image_name: sintef/pysilcam
-          image_tag: github-ci
+          image_name: ${{ IMAGE_NAME }}
+          image_tag: ${{ IMAGE_TAG }}
           context: .
           dockerfile: Dockerfile
 
@@ -32,4 +36,4 @@ jobs:
           unzip temp.zip
 
       - name: Run the tests
-        run: docker run -v $PWD/pysilcam-testdata:/testdata sintef/pysilcam:github-ci
+        run: docker run -v $PWD/pysilcam-testdata:/testdata ${IMAGE_NAME}:${IMAGE_TAG}

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -13,13 +13,15 @@ jobs:
       - name: Build the Docker image
         run: docker build . -f Dockerfile -t pysilcam
 
-      - name: Checkout test data
-        uses: actions/checkout@v2
-        with:
-          repository: SINTEF/pysilcam-testdata
-          lfs: true
-          path: testdata
+      - name: Download test data
+        shell: bash
+        env:
+          AZURE_TEST_DATA_ACCESS_TOKEN: ${{ secrets.AZURE_TEST_DATA_ACCESS_TOKEN }}
+        run: |
+          wget https://pysilcam.blob.core.windows.net/test-data/pysilcam-testdata.zip?$AZURE_TEST_DATA_ACCESS_TOKEN -O temp.zip
+          unzip temp.zip
+          ls -al
+          ls pysilcam-testdata/ -al
 
       - name: Run the tests
-        run: docker run -v testdata:/testdata pysilcam
-
+        run: docker run -v pysilcam-testdata:/testdata pysilcam

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -22,8 +22,8 @@ jobs:
           # username: <username>
           # password: ${{ secrets.DOCKER_REGISTRY_ACCESS_TOKEN }}
           # registry: <docker registry> (default: Docker Hub's registry).
-          image_name: ${{ IMAGE_NAME }}
-          image_tag: ${{ IMAGE_TAG }}
+          image_name: ${{ env.IMAGE_NAME }}
+          image_tag: ${{ env.IMAGE_TAG }}
           context: .
           dockerfile: Dockerfile
 

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -1,10 +1,6 @@
 name: Docker build and test
 
-on:
-  push:
-    branches: [ public ]
-  pull_request:
-    branches: [ public ]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -15,6 +11,13 @@ jobs:
 
       - name: Build the Docker image
         run: docker build . -f Dockerfile -t pysilcam
+
+      - name: Checkout test data
+        uses: actions/checkout@v2
+        with:
+          repository: SINTEF/pysilcam-testdata
+          lfs: true
+          path: testdata
 
       - name: Run the tests
         run: docker run pysilcam

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -33,7 +33,7 @@ jobs:
           unzip temp.zip
 
       - name: Inspect testdata
-        run: docker run -v $PWD/pysilcam-testdata:/testdata pysilcam ls /testdata -al
+        run: docker run -v $PWD/pysilcam-testdata:/testdata tankefugl/pysilcam ls /testdata -al
 
       - name: Run the tests
-        run: docker run -v $PWD/pysilcam-testdata:/testdata pysilcam
+        run: docker run -v $PWD/pysilcam-testdata:/testdata tankefugl/pysilcam

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -12,17 +12,16 @@ jobs:
 
       - uses: whoan/docker-build-with-cache-action@v4
         with:
-          #push_image_and_stages: true  # useful when you are setting a workflow to run on PRs
-          username: tankefugl
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-          #registry: Docker registry (default: Docker Hub's registry).
-          image_name: tankefugl/pysilcam #sintef/pysilcam?
+          # The following needs to be commented out to use docker caching
+          # push_image_and_stages: true
+          push_image_and_stages: false
+          # username: <username>
+          # password: ${{ secrets.DOCKER_REGISTRY_ACCESS_TOKEN }}
+          # registry: <docker registry> (default: Docker Hub's registry).
+          image_name: sintef/pysilcam
           image_tag: github-ci
           context: .
           dockerfile: Dockerfile
-
-      # - name: Build the Docker image
-      #   run: docker build . -f Dockerfile -t pysilcam
 
       - name: Download test data
         shell: bash
@@ -32,8 +31,5 @@ jobs:
           wget -nv https://pysilcam.blob.core.windows.net/test-data/pysilcam-testdata.zip?$AZURE_TEST_DATA_ACCESS_TOKEN -O temp.zip
           unzip temp.zip
 
-      - name: Inspect testdata
-        run: docker run -v $PWD/pysilcam-testdata:/testdata tankefugl/pysilcam:github-ci ls /testdata -al
-
       - name: Run the tests
-        run: docker run -v $PWD/pysilcam-testdata:/testdata tankefugl/pysilcam:github-ci
+        run: docker run -v $PWD/pysilcam-testdata:/testdata sintef/pysilcam:github-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ EXPOSE 5920
 ENV PYTHONDONTWRITEBYTECODE FALSE
 
 # Assume that test data is mounted into the testdata path
-ENV UNITTEST_DATA_PATH /testdata
+ENV UNITTEST_DATA_PATH /testdata/unittest-data
+ENV SILCAM_MODEL_PATH /testdata/tflmodel
 
 # Add the Pysilcam source directory to the container in order to install Pysilcam
 ADD . /silcam

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ WORKDIR /silcam
 RUN python setup.py develop
 
 # Run the PySilCam tests as default entrypoint
-ENTRYPOINT ["python", "setup.py", "test"]
+CMD ["python", "setup.py", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV PYTHONDONTWRITEBYTECODE FALSE
 
 # Assume that test data is mounted into the testdata path
 ENV UNITTEST_DATA_PATH /testdata/unittest-data
-ENV SILCAM_MODEL_PATH /testdata/tflmodel/
+ENV SILCAM_MODEL_PATH /testdata/tflmodel/particle-classifier.tfl
 
 # Add the Pysilcam source directory to the container in order to install Pysilcam
 ADD . /silcam

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ EXPOSE 5920
 # Make Python not create .pyc files
 ENV PYTHONDONTWRITEBYTECODE FALSE
 
+# Assume that test data is mounted into the testdata path
+ENV UNITTEST_DATA_PATH /testdata
+
 # Add the Pysilcam source directory to the container in order to install Pysilcam
 ADD . /silcam
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV PYTHONDONTWRITEBYTECODE FALSE
 
 # Assume that test data is mounted into the testdata path
 ENV UNITTEST_DATA_PATH /testdata/unittest-data
-ENV SILCAM_MODEL_PATH /testdata/tflmodel
+ENV SILCAM_MODEL_PATH /testdata/tflmodel/
 
 # Add the Pysilcam source directory to the container in order to install Pysilcam
 ADD . /silcam

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ENV PYTHONDONTWRITEBYTECODE FALSE
 ENV UNITTEST_DATA_PATH /testdata/unittest-data
 ENV SILCAM_MODEL_PATH /testdata/tflmodel/particle-classifier.tfl
 
+# Supress the usage of a display for unit tests
+ENV MPLBACKEND Agg
+
 # Add the Pysilcam source directory to the container in order to install Pysilcam
 ADD . /silcam
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Create a virtual environment (preferably containing a username, example below is
     conda create -n <name of the environment> python=3.5
 ```
 
-Unix: 
+Unix:
 
 ```
-    source activate sctest 
+    source activate sctest
 ```
-    
-Windows: 
+
+Windows:
 
 ```
     activate sctest
@@ -110,4 +110,4 @@ If you want to mount a local folder inside the docker environment, use -v [local
 License
 -------
 
-BSD3 license. See LICENSE
+PySilCam is licensed under the BSD3 license. See LICENSE


### PR DESCRIPTION
This pull request enables all unit tests running in GitHub actions. It also adds the scaffolding needed to add caching to the docker image building, which needs a docker repository account to be set up completely.